### PR TITLE
Add SPSC memory queue

### DIFF
--- a/sindri/Cargo.toml
+++ b/sindri/Cargo.toml
@@ -10,6 +10,7 @@ aes-gcm = "0.9"
 ecdsa = { version = "0.12", default-features = false }
 elliptic-curve = { version = "0.10", default-features = false }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
+heapless = { version = "0.7", default-features = false }
 p256 = { version = "0.9", default-features = false, features = ["ecdh", "ecdsa"] }
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }

--- a/sindri/src/crypto/ecdsa.rs
+++ b/sindri/src/crypto/ecdsa.rs
@@ -11,11 +11,6 @@ use ecdsa::{Curve, Signature, SignatureSize, SigningKey, VerifyingKey};
 
 pub use crate::crypto::ecc::gen_key_pair;
 
-#[derive(Debug)]
-pub enum Error {
-    Sign,
-}
-
 pub fn sign<C>(key: &SecretKey<C>, message: &[u8]) -> Signature<C>
 where
     C: Curve + ProjectiveArithmetic + DigestPrimitive,

--- a/sindri/src/lib.rs
+++ b/sindri/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 pub mod crypto;
+pub mod queue;
 
 #[cfg(test)]
 mod tests {

--- a/sindri/src/queue.rs
+++ b/sindri/src/queue.rs
@@ -1,0 +1,88 @@
+use heapless::spsc::Queue;
+
+#[derive(Debug)]
+pub enum Error {
+    BufferSize,
+}
+
+/// Create SPSC queue in preallocated memory buffer.
+///
+/// # Arguments
+///
+/// * `buffer`: Preallocated buffer of at least `core::mem::size_of::Queue<T, { N }>()` size.
+///
+/// # Safety
+///
+/// This function will use raw memory access to create a new queue in the provided memory buffer.
+/// The caller must make sure that the memory buffer is not reused or freed before the the returned
+/// queue is dropped.
+///
+/// # Examples
+///
+/// ```
+/// use heapless::spsc::Queue;
+/// type Element = u32;
+///
+/// const QUEUE_ELEMENTS: usize = 10;
+/// const QUEUE_BYTES: usize = core::mem::size_of::<Queue<Element, QUEUE_ELEMENTS>>();
+/// static mut QUEUE_BUFFER: [u8; QUEUE_BYTES] = [0u8; QUEUE_BYTES];
+/// let queue = unsafe { sindri::queue::create_queue_in_buffer::<Element, QUEUE_ELEMENTS>(&mut QUEUE_BUFFER) };
+/// ```
+pub unsafe fn create_queue_in_buffer<T, const N: usize>(
+    buffer: &mut [u8],
+) -> Result<&mut Queue<T, N>, Error> {
+    if buffer.len() < core::mem::size_of::<Queue<T, N>>() {
+        return Err(Error::BufferSize);
+    }
+    core::ptr::write(
+        buffer.as_mut_ptr() as *mut Queue<T, N>,
+        Queue::<T, N>::new(),
+    );
+    Ok(&mut *(buffer.as_mut_ptr() as *mut Queue<T, N>))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    type Element = u32;
+
+    #[test]
+    fn create_queue() -> Result<(), Error> {
+        // Simulate externally defined memory region
+        const QUEUE_ELEMENTS: usize = 10;
+        const QUEUE_BYTES: usize = core::mem::size_of::<Queue<Element, QUEUE_ELEMENTS>>();
+        static mut QUEUE_BUFFER: [u8; QUEUE_BYTES] = [0u8; QUEUE_BYTES];
+
+        // Create queue
+        let queue =
+            unsafe { create_queue_in_buffer::<Element, QUEUE_ELEMENTS>(&mut QUEUE_BUFFER) }?;
+        let (mut producer, mut consumer) = queue.split();
+
+        // Use queue
+        assert_eq!(producer.len(), 0);
+        assert_eq!(consumer.len(), 0);
+        let element_in = 0x12345678;
+        assert!(producer.enqueue(element_in.clone()).is_ok());
+        assert_eq!(producer.len(), 1);
+        assert_eq!(consumer.len(), 1);
+        let element_out = consumer.dequeue().unwrap();
+        assert_eq!(producer.len(), 0);
+        assert_eq!(consumer.len(), 0);
+        assert_eq!(element_in, element_out);
+        Ok(())
+    }
+
+    #[test]
+    fn create_queue_buffer_too_small() {
+        const QUEUE_ELEMENTS: usize = 10;
+        const QUEUE_BYTES: usize = core::mem::size_of::<Queue<Element, QUEUE_ELEMENTS>>() - 1; // Buffer is too short
+        static mut QUEUE_BUFFER: [u8; QUEUE_BYTES] = [0u8; QUEUE_BYTES];
+        match unsafe { create_queue_in_buffer::<Element, QUEUE_ELEMENTS>(&mut QUEUE_BUFFER) } {
+            Err(Error::BufferSize) => {}
+            _ => {
+                panic!("Expected error during queue creation.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add function to (unsafely) instantiate a queue in a given memory region.
This code should eventually be called by the security core to initialize the queues needed for inter-core communication.