### PR TITLE
Remove async support

### DIFF
--- a/linux_poc/src/main.rs
+++ b/linux_poc/src/main.rs
@@ -99,9 +99,7 @@ async fn host_task(
     let mut core = Core::new(&POOL, rng, channels);
 
     loop {
-        core.process_next()
-            .await
-            .expect("failed to process next request");
+        core.process_next().expect("failed to process next request");
         Timer::after(Duration::from_millis(100)).await;
     }
 }

--- a/sindri/Cargo.lock
+++ b/sindri/Cargo.lock
@@ -323,84 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
-
-[[package]]
-name = "futures-task"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
-
-[[package]]
-name = "futures-test"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee87d68bf5bca8a0270f477fa1ceab0fbdf735fa21ea17e617ed5381b634fa4"
-dependencies = [
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "futures-util",
- "pin-project",
- "pin-utils",
-]
-
-[[package]]
-name = "futures-util"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,38 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,24 +497,6 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "rand"
@@ -790,7 +662,6 @@ dependencies = [
  "chacha20poly1305",
  "ecdsa",
  "elliptic-curve",
- "futures-test",
  "generic-array",
  "heapless",
  "hex",
@@ -799,15 +670,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "sha2",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -832,27 +694,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
-name = "syn"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "universal-hash"

--- a/sindri/Cargo.toml
+++ b/sindri/Cargo.toml
@@ -20,6 +20,5 @@ rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10" , default-features = false }
 
 [dev-dependencies]
-futures-test = "0.3"
 heapless = "0.7"
 hex = "0.4"

--- a/sindri/tests/api_core_integration.rs
+++ b/sindri/tests/api_core_integration.rs
@@ -63,8 +63,8 @@ mod test {
         }
     }
 
-    #[futures_test::test]
-    async fn api_core_communication() {
+    #[test]
+    fn api_core_communication() {
         // Pool
         static mut MEMORY: Memory = [0; Pool::required_memory()];
         static POOL: Pool = Pool::new();
@@ -102,9 +102,7 @@ mod test {
         let random_size = 16;
         hsm.get_random(random_size)
             .expect("failed to call randomness API");
-        core.process_next()
-            .await
-            .expect("failed to process next request");
+        core.process_next().expect("failed to process next request");
 
         // Receive response
         let response = hsm.recv_response().expect("failed to receive response");

--- a/stm32h745i/cm7/src/bin/rng_single_core.rs
+++ b/stm32h745i/cm7/src/bin/rng_single_core.rs
@@ -115,9 +115,7 @@ async fn host_task(
     let mut core = Core::new(&POOL, rng, channels);
 
     loop {
-        core.process_next()
-            .await
-            .expect("failed to process next request");
+        core.process_next().expect("failed to process next request");
         Timer::after(Duration::from_millis(100)).await;
     }
 }


### PR DESCRIPTION
Remove async support for now as the current code is not running asynchronously anyway. Sindri will most likely run on a single core machine so the only point would of async is to either
a) interrupt long-running software computations or
b) hand over computations to dedicated hardware engines.

The first case requires the crypto crates that we use to support async as well. As of now, none of the crates we use does this. Whether or not the second case will be implemented using async is not clear yet. Until then, we continue non-async.