### PR TITLE
Switch to shared memory instead of HSM allocations

### DIFF
--- a/heimlig/src/common/jobs.rs
+++ b/heimlig/src/common/jobs.rs
@@ -1,4 +1,5 @@
-use crate::common::pool::PoolChunk;
+use core::ptr::NonNull;
+
 use crate::hsm::keystore;
 use crate::hsm::keystore::Id;
 
@@ -14,41 +15,138 @@ pub enum Error {
     KeyStore(keystore::Error),
 }
 
+/// Shared memory representation.
+#[derive(Eq, PartialEq, Debug)]
+pub struct ExternalMemory {
+    /// Pointer to memory.
+    ptr: *const u8,
+    /// Memory size.
+    size: usize,
+}
+
+impl ExternalMemory {
+    pub fn new(ptr: *const u8, size: usize) -> Self {
+        Self { ptr, size }
+    }
+
+    pub fn from_slice(data: &[u8]) -> Self {
+        Self::new(data.as_ptr(), data.len())
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.ptr, self.size) }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.ptr as *mut _, self.size) }
+    }
+}
+
+impl Default for ExternalMemory {
+    fn default() -> Self {
+        Self {
+            ptr: NonNull::<u8>::dangling().as_ptr(),
+            size: 0,
+        }
+    }
+}
+
+/// Shared memory input parameter.
+#[derive(Eq, PartialEq, Debug, Default)]
+pub struct InParam {
+    /// Shared memory.
+    memory: ExternalMemory,
+}
+
+impl InParam {
+    pub fn new(memory: ExternalMemory) -> Self {
+        Self { memory }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.memory.as_slice()
+    }
+}
+
+/// Shared memory output parameter.
+#[derive(Eq, PartialEq, Debug, Default)]
+pub struct OutParam {
+    /// Shared memory.
+    memory: ExternalMemory,
+}
+
+impl OutParam {
+    pub fn new(memory: ExternalMemory) -> Self {
+        Self { memory }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.memory.as_slice()
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.memory.as_mut_slice()
+    }
+}
+
+/// Shared memory in/out parameter.
+#[derive(Eq, PartialEq, Debug, Default)]
+pub struct InOutParam {
+    /// Shared memory.
+    memory: ExternalMemory,
+}
+
+impl InOutParam {
+    pub fn new(memory: ExternalMemory) -> Self {
+        Self { memory }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.memory.as_slice()
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.memory.as_mut_slice()
+    }
+}
+
 /// A request for the HSM to perform a cryptographic task.
 #[derive(Eq, PartialEq, Debug)]
 pub enum Request {
     ImportKey {
         id: Id,
-        data: PoolChunk,
+        data: InParam,
     },
     GetRandom {
-        size: usize,
+        data: OutParam,
     },
     EncryptChaChaPoly {
         key_id: Id,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        plaintext: PoolChunk,
+        nonce: InParam,
+        aad: Option<InParam>,
+        plaintext: InOutParam,
+        tag: OutParam,
     },
     EncryptChaChaPolyExternalKey {
-        key: PoolChunk,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        plaintext: PoolChunk,
+        key: InParam,
+        nonce: InParam,
+        aad: Option<InParam>,
+        plaintext: InOutParam,
+        tag: OutParam,
     },
     DecryptChaChaPoly {
         key_id: Id,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        ciphertext: PoolChunk,
-        tag: PoolChunk,
+        nonce: InParam,
+        aad: Option<InParam>,
+        ciphertext: InOutParam,
+        tag: InParam,
     },
     DecryptChaChaPolyExternalKey {
-        key: PoolChunk,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        ciphertext: PoolChunk,
-        tag: PoolChunk,
+        key: InParam,
+        nonce: InParam,
+        aad: Option<InParam>,
+        ciphertext: InOutParam,
+        tag: InParam,
     },
 }
 
@@ -58,13 +156,13 @@ pub enum Response {
     ImportKey,
     Error(Error),
     GetRandom {
-        data: PoolChunk,
+        data: OutParam,
     },
     EncryptChaChaPoly {
-        ciphertext: PoolChunk,
-        tag: PoolChunk,
+        ciphertext: InOutParam,
+        tag: OutParam,
     },
     DecryptChaChaPoly {
-        plaintext: PoolChunk,
+        plaintext: InOutParam,
     },
 }

--- a/heimlig/src/hsm/scheduler/tests.rs
+++ b/heimlig/src/hsm/scheduler/tests.rs
@@ -1,4 +1,6 @@
-use crate::common::jobs::{Error, Request, Response};
+use crate::common::jobs::{
+    Error, ExternalMemory, InOutParam, InParam, OutParam, Request, Response,
+};
 use crate::common::limits::MAX_RANDOM_SIZE;
 use crate::common::pool::{Memory, Pool, PoolChunk};
 use crate::config;
@@ -32,8 +34,11 @@ fn get_random() {
         { config::keystore::NUM_KEYS },
     >::try_new(&key_infos)
     .expect("failed to create key store");
+    let data = pool.alloc(32).unwrap();
     let mut scheduler = init_scheduler(&pool, &mut key_store);
-    let request = Request::GetRandom { size: 32 };
+    let request = Request::GetRandom {
+        data: OutParam::new(ExternalMemory::from_slice(data.as_slice())),
+    };
     let job = Job {
         channel_id: 0,
         request,
@@ -46,7 +51,7 @@ fn get_random() {
             panic!("Unexpected response type");
         }
     };
-    assert_eq!(response_data.len(), 32);
+    assert_eq!(response_data.as_slice().len(), 32);
 }
 
 #[test]
@@ -60,8 +65,9 @@ fn get_random_request_too_large() {
     >::try_new(&key_infos)
     .expect("failed to create key store");
     let mut scheduler = init_scheduler(&pool, &mut key_store);
+    let data = [0u8; MAX_RANDOM_SIZE + 1];
     let request = Request::GetRandom {
-        size: MAX_RANDOM_SIZE + 1,
+        data: OutParam::new(ExternalMemory::from_slice(data.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -74,7 +80,7 @@ fn get_random_request_too_large() {
     ))
 }
 
-fn alloc_chachapoly_vars(pool: &Pool) -> (PoolChunk, PoolChunk, PoolChunk, PoolChunk) {
+fn alloc_chachapoly_vars(pool: &Pool) -> (PoolChunk, PoolChunk, PoolChunk, PoolChunk, PoolChunk) {
     const KEY: &[u8; KEY_SIZE] = b"Fortuna Major or Oddsbodikins???";
     const NONCE: &[u8; NONCE_SIZE] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     const PLAINTEXT: &[u8] = b"I solemnly swear I am up to no good!";
@@ -86,7 +92,10 @@ fn alloc_chachapoly_vars(pool: &Pool) -> (PoolChunk, PoolChunk, PoolChunk, PoolC
     aad.as_slice_mut().copy_from_slice(AAD);
     let mut plaintext = pool.alloc(PLAINTEXT.len()).unwrap();
     plaintext.as_slice_mut().copy_from_slice(PLAINTEXT);
-    (key, nonce, aad, plaintext)
+    let tag = pool
+        .alloc(crate::crypto::chacha20poly1305::TAG_SIZE)
+        .unwrap();
+    (key, nonce, aad, plaintext, tag)
 }
 
 #[test]
@@ -102,10 +111,10 @@ fn encrypt_chachapoly() {
     let mut scheduler = init_scheduler(&pool, &mut key_store);
 
     // Import key
-    let (key, nonce, aad, plaintext) = alloc_chachapoly_vars(&pool);
+    let (key, nonce, aad, plaintext, tag) = alloc_chachapoly_vars(&pool);
     let request = Request::ImportKey {
         id: KEY3.id,
-        data: key,
+        data: InParam::new(ExternalMemory::from_slice(key.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -121,9 +130,10 @@ fn encrypt_chachapoly() {
     // Encrypt data
     let request = Request::EncryptChaChaPoly {
         key_id: KEY3.id,
-        nonce,
-        aad: Some(aad),
-        plaintext,
+        nonce: InParam::new(ExternalMemory::from_slice(nonce.as_slice())),
+        aad: Some(InParam::new(ExternalMemory::from_slice(aad.as_slice()))),
+        plaintext: InOutParam::new(ExternalMemory::from_slice(plaintext.as_slice())),
+        tag: OutParam::new(ExternalMemory::from_slice(tag.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -137,13 +147,13 @@ fn encrypt_chachapoly() {
     };
 
     // Decrypt data
-    let (_key, nonce, aad, org_plaintext) = alloc_chachapoly_vars(&pool);
+    let (_key, nonce, aad, org_plaintext, _) = alloc_chachapoly_vars(&pool);
     let request = Request::DecryptChaChaPoly {
         key_id: KEY3.id,
-        nonce,
-        aad: Some(aad),
+        nonce: InParam::new(ExternalMemory::from_slice(nonce.as_slice())),
+        aad: Some(InParam::new(ExternalMemory::from_slice(aad.as_slice()))),
         ciphertext,
-        tag,
+        tag: InParam::new(ExternalMemory::from_slice(tag.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -171,12 +181,13 @@ fn encrypt_chachapoly_external_key() {
     let mut scheduler = init_scheduler(&pool, &mut key_store);
 
     // Encrypt data
-    let (key, nonce, aad, plaintext) = alloc_chachapoly_vars(&pool);
+    let (key, nonce, aad, plaintext, tag) = alloc_chachapoly_vars(&pool);
     let request = Request::EncryptChaChaPolyExternalKey {
-        key,
-        nonce,
-        aad: Some(aad),
-        plaintext,
+        key: InParam::new(ExternalMemory::from_slice(key.as_slice())),
+        nonce: InParam::new(ExternalMemory::from_slice(nonce.as_slice())),
+        aad: Some(InParam::new(ExternalMemory::from_slice(aad.as_slice()))),
+        plaintext: InOutParam::new(ExternalMemory::from_slice(plaintext.as_slice())),
+        tag: OutParam::new(ExternalMemory::from_slice(tag.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -190,13 +201,13 @@ fn encrypt_chachapoly_external_key() {
     };
 
     // Decrypt data
-    let (key, nonce, aad, org_plaintext) = alloc_chachapoly_vars(&pool);
+    let (key, nonce, aad, org_plaintext, _) = alloc_chachapoly_vars(&pool);
     let request = Request::DecryptChaChaPolyExternalKey {
-        key,
-        nonce,
-        aad: Some(aad),
+        key: InParam::new(ExternalMemory::from_slice(key.as_slice())),
+        nonce: InParam::new(ExternalMemory::from_slice(nonce.as_slice())),
+        aad: Some(InParam::new(ExternalMemory::from_slice(aad.as_slice()))),
         ciphertext,
-        tag,
+        tag: InParam::new(ExternalMemory::from_slice(tag.as_slice())),
     };
     let job = Job {
         channel_id: 0,
@@ -209,4 +220,39 @@ fn encrypt_chachapoly_external_key() {
         }
     };
     assert_eq!(plaintext.as_slice(), org_plaintext.as_slice())
+}
+
+#[test]
+fn encrypt_chachapoly_invalid_tag_size() {
+    static mut MEMORY: Memory = [0; Pool::required_memory()];
+    let pool = Pool::try_from(unsafe { &mut MEMORY }).unwrap();
+    let key_infos = [KEY1, KEY2, KEY3];
+    let mut key_store = MemoryKeyStore::<
+        { config::keystore::TOTAL_SIZE },
+        { config::keystore::NUM_KEYS },
+    >::try_new(&key_infos)
+    .expect("failed to create key store");
+    let mut scheduler = init_scheduler(&pool, &mut key_store);
+
+    // Encrypt data
+    let (key, nonce, aad, plaintext, _) = alloc_chachapoly_vars(&pool);
+    let tag = pool
+        .alloc(crate::crypto::chacha20poly1305::TAG_SIZE + 1)
+        .expect("failed to allocate invalid tag");
+    let request = Request::EncryptChaChaPolyExternalKey {
+        key: InParam::new(ExternalMemory::from_slice(key.as_slice())),
+        nonce: InParam::new(ExternalMemory::from_slice(nonce.as_slice())),
+        aad: Some(InParam::new(ExternalMemory::from_slice(aad.as_slice()))),
+        plaintext: InOutParam::new(ExternalMemory::from_slice(plaintext.as_slice())),
+        tag: OutParam::new(ExternalMemory::from_slice(tag.as_slice())),
+    };
+    let job = Job {
+        channel_id: 0,
+        request,
+    };
+
+    assert_eq!(
+        Response::Error(Error::Crypto(crate::crypto::Error::InvalidTagSize)),
+        scheduler.schedule(job).response
+    );
 }

--- a/heimlig/src/hsm/workers/chachapoly_worker.rs
+++ b/heimlig/src/hsm/workers/chachapoly_worker.rs
@@ -1,5 +1,5 @@
-use crate::common::jobs::{Error, Response};
-use crate::common::pool::{Pool, PoolChunk};
+use crate::common::jobs::{Error, InOutParam, InParam, OutParam, Response};
+use crate::common::pool::Pool;
 
 pub struct ChachaPolyWorker<'a> {
     pub pool: &'a Pool,
@@ -8,54 +8,49 @@ pub struct ChachaPolyWorker<'a> {
 impl<'a> ChachaPolyWorker<'a> {
     pub fn encrypt_external_key(
         &mut self,
-        key: PoolChunk,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        ciphertext: PoolChunk,
+        key: InParam,
+        nonce: InParam,
+        aad: Option<InParam>,
+        ciphertext: InOutParam,
+        tag: OutParam,
     ) -> Response {
-        self.encrypt(key.as_slice(), nonce, aad, ciphertext)
+        self.encrypt(key.as_slice(), nonce, aad, ciphertext, tag)
     }
 
     pub fn encrypt(
         &mut self,
         key: &[u8],
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        mut ciphertext: PoolChunk,
+        nonce: InParam,
+        aad: Option<InParam>,
+        mut ciphertext: InOutParam,
+        mut tag: OutParam,
     ) -> Response {
-        match self.pool.alloc(crate::crypto::chacha20poly1305::TAG_SIZE) {
-            Err(_) => Response::Error(Error::Alloc),
-            Ok(mut tag) => {
-                let aad = match &aad {
-                    Some(aad) => aad.as_slice(),
-                    None => &[] as &[u8],
-                };
-                match crate::crypto::chacha20poly1305::encrypt_in_place_detached(
-                    key,
-                    nonce.as_slice(),
-                    aad,
-                    ciphertext.as_slice_mut(),
-                ) {
-                    Ok(computed_tag) => {
-                        if computed_tag.len() != tag.as_slice().len() {
-                            return Response::Error(Error::Alloc);
-                        }
-                        tag.as_slice_mut().copy_from_slice(computed_tag.as_slice());
-                        Response::EncryptChaChaPoly { ciphertext, tag }
-                    }
-                    Err(e) => Response::Error(Error::Crypto(e)),
+        let aad = aad.unwrap_or_default();
+        match crate::crypto::chacha20poly1305::encrypt_in_place_detached(
+            key,
+            nonce.as_slice(),
+            aad.as_slice(),
+            ciphertext.as_mut_slice(),
+        ) {
+            Ok(computed_tag) => {
+                if computed_tag.len() != tag.as_slice().len() {
+                    return Response::Error(Error::Crypto(crate::crypto::Error::InvalidTagSize));
                 }
+
+                tag.as_mut_slice().copy_from_slice(computed_tag.as_slice());
+                Response::EncryptChaChaPoly { ciphertext, tag }
             }
+            Err(e) => Response::Error(Error::Crypto(e)),
         }
     }
 
     pub fn decrypt_external_key(
         &mut self,
-        key: PoolChunk,
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        plaintext: PoolChunk,
-        tag: PoolChunk,
+        key: InParam,
+        nonce: InParam,
+        aad: Option<InParam>,
+        plaintext: InOutParam,
+        tag: InParam,
     ) -> Response {
         self.decrypt(key.as_slice(), nonce, aad, plaintext, tag)
     }
@@ -63,20 +58,17 @@ impl<'a> ChachaPolyWorker<'a> {
     pub fn decrypt(
         &mut self,
         key: &[u8],
-        nonce: PoolChunk,
-        aad: Option<PoolChunk>,
-        mut plaintext: PoolChunk,
-        tag: PoolChunk,
+        nonce: InParam,
+        aad: Option<InParam>,
+        mut plaintext: InOutParam,
+        tag: InParam,
     ) -> Response {
-        let aad = match &aad {
-            Some(aad) => aad.as_slice(),
-            None => &[] as &[u8],
-        };
+        let aad = aad.unwrap_or_default();
         match crate::crypto::chacha20poly1305::decrypt_in_place_detached(
             key,
             nonce.as_slice(),
-            aad,
-            plaintext.as_slice_mut(),
+            aad.as_slice(),
+            plaintext.as_mut_slice(),
             tag.as_slice(),
         ) {
             Ok(()) => Response::DecryptChaChaPoly { plaintext },


### PR DESCRIPTION
Allocate shared memory on the client side and pass addresses of output parameters to HSM.