### PR TITLE
Update aes-gcm to fix security issue

### DIFF
--- a/examples/linux/Cargo.lock
+++ b/examples/linux/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",

--- a/examples/linux/Cargo.lock
+++ b/examples/linux/Cargo.lock
@@ -617,7 +617,6 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "embassy-sync",
- "generic-array",
  "heapless",
  "p256",
  "p384",

--- a/examples/stm32h745i/cm4/Cargo.lock
+++ b/examples/stm32h745i/cm4/Cargo.lock
@@ -896,7 +896,6 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "embassy-sync 0.3.0",
- "generic-array",
  "heapless",
  "p256",
  "p384",

--- a/examples/stm32h745i/cm4/Cargo.lock
+++ b/examples/stm32h745i/cm4/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -515,7 +515,7 @@ source = "git+https://github.com/embassy-rs/embassy.git#2a4ebdc150ba7c32d7dacc12
 dependencies = [
  "defmt",
  "embassy-futures",
- "embassy-sync 0.2.0 (git+https://github.com/embassy-rs/embassy.git)",
+ "embassy-sync 0.2.0",
  "embassy-time",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-rc.1",
@@ -593,14 +593,14 @@ dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-net-driver",
- "embassy-sync 0.2.0 (git+https://github.com/embassy-rs/embassy.git)",
+ "embassy-sync 0.2.0",
  "embassy-time",
  "embassy-usb-driver",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-rc.1",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io 0.5.0",
+ "embedded-io",
  "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
@@ -619,24 +619,23 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0dad296a6f70bfdc32ef52442a31f98c28e1608893c1cecc9b6f419bab005a0"
+source = "git+https://github.com/embassy-rs/embassy.git#2a4ebdc150ba7c32d7dacc12aec85bccf05a41ff"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io 0.4.0",
+ "defmt",
  "futures-util",
  "heapless",
 ]
 
 [[package]]
 name = "embassy-sync"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#2a4ebdc150ba7c32d7dacc12aec85bccf05a41ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0525b466ca3ace30b57f2db868a35215dfaecd038d8668cb2db03feb7c069a0"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt",
  "futures-util",
  "heapless",
 ]
@@ -702,12 +701,6 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
@@ -722,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1394754ad749a560b25a0c70dcd2b66a450824a1311fc475bb2ccbfabe7f8414"
 dependencies = [
  "defmt",
- "embedded-io 0.5.0",
+ "embedded-io",
 ]
 
 [[package]]
@@ -902,7 +895,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
- "embassy-sync 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embassy-sync 0.3.0",
  "generic-array",
  "heapless",
  "p256",

--- a/examples/stm32h745i/cm7/Cargo.lock
+++ b/examples/stm32h745i/cm7/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",

--- a/examples/stm32h745i/cm7/Cargo.lock
+++ b/examples/stm32h745i/cm7/Cargo.lock
@@ -912,7 +912,6 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "embassy-sync 0.3.0",
- "generic-array",
  "heapless",
  "p256",
  "p384",

--- a/heimlig/Cargo.lock
+++ b/heimlig/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",

--- a/heimlig/Cargo.lock
+++ b/heimlig/Cargo.lock
@@ -461,7 +461,6 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "embassy-sync",
- "generic-array",
  "heapless",
  "hex",
  "p256",

--- a/heimlig/Cargo.toml
+++ b/heimlig/Cargo.toml
@@ -19,7 +19,6 @@ ecdsa = { version = "0.16", default-features = false }
 ed25519-dalek = { version = "2.0", default-features = false, features = ["zeroize"] }
 elliptic-curve = { version = "0.13", default-features = false }
 embassy-sync = { version = "0.3", default-features = false }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
 heapless = { version = "0.7", default-features = false, features = ["cas", "x86-sync-pool"] }
 p256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa"] }
 p384 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa"] }

--- a/heimlig/Cargo.toml
+++ b/heimlig/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/esrlabs/heimlig"
 
 [dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.10.3", default-features = false, features = ["aes"] }
 blake3 = { version = "1", default-features = false }
 cbc = { version = "0.1", default-features = false, features = ["block-padding", "zeroize"] }
 ccm = { version = "0.5", default-features = false }

--- a/heimlig/src/crypto/aes/gcm.rs
+++ b/heimlig/src/crypto/aes/gcm.rs
@@ -1,4 +1,5 @@
 use crate::crypto::{check_sizes, check_sizes_with_tag, Error};
+use aes::{cipher::typenum::Same, cipher::Unsigned};
 use aes_gcm::{
     aead::{
         consts::{U12, U16},
@@ -6,7 +7,6 @@ use aes_gcm::{
     },
     AeadInPlace, Aes128Gcm, Aes256Gcm, KeyInit,
 };
-use generic_array::typenum::{Same, Unsigned};
 
 pub type SupportedNonceSize = U12;
 pub type SupportedTagSize = U16;


### PR DESCRIPTION
See https://github.com/eclipse-heimlig/heimlig/security/dependabot/11