### PR TITLE
Remove unused dependency `either`

### DIFF
--- a/heimlig/Cargo.lock
+++ b/heimlig/Cargo.lock
@@ -511,12 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
 name = "elliptic-curve"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,7 +763,6 @@ dependencies = [
  "critical-section",
  "ecdsa",
  "ed25519-dalek",
- "either",
  "elliptic-curve",
  "embassy-futures",
  "embassy-sync",

--- a/heimlig/Cargo.toml
+++ b/heimlig/Cargo.toml
@@ -18,7 +18,6 @@ chacha20poly1305 = { version = "0.10.1", default-features = false }
 critical-section = { version = "1.1.2", default-features = false }
 ecdsa = { version = "0.16.8", default-features = false }
 ed25519-dalek = { version = "2.0.0", default-features = false, features = ["zeroize"] }
-either = { version = "1.9.0", default-features = false }
 elliptic-curve = { version = "0.13.5", default-features = false }
 embassy-futures = { version = "0.1.0", default-features = false }
 embassy-sync = { version = "0.3.0", default-features = false }


### PR DESCRIPTION
Hi! I think the dependency `either` is not used in the project any longer and can be removed.