### PR TITLE
Refactor KeyStore

### DIFF
--- a/heimlig/src/hsm/keystore.rs
+++ b/heimlig/src/hsm/keystore.rs
@@ -332,7 +332,7 @@ impl<T: InsecureKeyStore> KeyStore for T {
         }
         self.delete_insecure(id)
     }
-        fn is_key_available(&self, id: KeyId) -> bool {
+    fn is_key_available(&self, id: KeyId) -> bool {
         self.is_key_available(id)
     }
 

--- a/heimlig/src/hsm/keystore.rs
+++ b/heimlig/src/hsm/keystore.rs
@@ -164,7 +164,7 @@ pub trait InsecureKeyStore {
     /// Delete the key for given ID.
     ///
     /// return: An error, if the key could not be found.
-    fn delete(&mut self, id: KeyId) -> Result<(), Error>;
+    fn delete_insecure(&mut self, id: KeyId) -> Result<(), Error>;
 
     /// Returns whether or not a key for the given 'id' is present in the store.
     fn is_key_available(&self, id: KeyId) -> bool;
@@ -193,25 +193,6 @@ pub trait KeyStore {
         overwrite: bool,
     ) -> Result<(), Error>;
 
-    /// Write symmetric key to storage.
-    ///
-    /// Unlike `import_symmetric_key()`, this function imports keys even if their permissions do not
-    /// allow to do so. It is supposed to be used by workers and is not reachable from outside
-    /// Heimlig. Workers operate inside Heimlig and are trusted.
-    fn import_symmetric_key_insecure(&mut self, id: KeyId, data: &[u8]) -> Result<(), Error>;
-
-    /// Write asymmetric key pair to storage.
-    ///
-    /// Unlike `import_key_pair()`, this function imports keys even if their permissions do not
-    /// allow to do so. It is supposed to be used by workers and is not reachable from outside
-    /// Heimlig. Workers operate inside Heimlig and are trusted.
-    fn import_key_pair_insecure(
-        &mut self,
-        id: KeyId,
-        public_key: &[u8],
-        private_key: &[u8],
-    ) -> Result<(), Error>;
-
     /// Read symmetric key from storage.
     ///
     /// returns: The number of bytes written to `dest` or and error.
@@ -234,32 +215,6 @@ pub trait KeyStore {
     ///
     /// returns: The number of bytes written to `dest` or and error.
     fn export_private_key<'data>(
-        &self,
-        id: KeyId,
-        dest: &'data mut [u8],
-    ) -> Result<&'data [u8], Error>;
-
-    /// Read symmetric key from storage.
-    ///
-    /// Unlike `export_symmetric_key()`, this function exports keys even if their permissions do not
-    /// allow to do so. It is supposed to be used by workers and is not reachable from outside
-    /// Heimlig. Workers operate inside Heimlig and are trusted.
-    ///
-    /// returns: The number of bytes written to `dest` or and error.
-    fn export_symmetric_key_insecure<'data>(
-        &self,
-        id: KeyId,
-        dest: &'data mut [u8],
-    ) -> Result<&'data [u8], Error>;
-
-    /// Read asymmetric private key from storage.
-    ///
-    /// Unlike `export_private_key()`, this function exports keys even if their permissions do not
-    /// allow to do so. It is supposed to be used by workers and is not reachable from outside
-    /// Heimlig. Workers operate inside Heimlig and are trusted.
-    ///
-    /// returns: The number of bytes written to `dest` or and error.
-    fn export_private_key_insecure<'data>(
         &self,
         id: KeyId,
         dest: &'data mut [u8],
@@ -328,19 +283,6 @@ impl<T: InsecureKeyStore> KeyStore for T {
         self.import_key_pair_insecure(id, public_key, private_key)
     }
 
-    fn import_symmetric_key_insecure(&mut self, id: KeyId, data: &[u8]) -> Result<(), Error> {
-        self.import_symmetric_key_insecure(id, data)
-    }
-
-    fn import_key_pair_insecure(
-        &mut self,
-        id: KeyId,
-        public_key: &[u8],
-        private_key: &[u8],
-    ) -> Result<(), Error> {
-        self.import_key_pair_insecure(id, public_key, private_key)
-    }
-
     fn export_symmetric_key<'data>(
         &self,
         id: KeyId,
@@ -383,31 +325,14 @@ impl<T: InsecureKeyStore> KeyStore for T {
         self.export_private_key_insecure(id, dest)
     }
 
-    fn export_symmetric_key_insecure<'data>(
-        &self,
-        id: KeyId,
-        dest: &'data mut [u8],
-    ) -> Result<&'data [u8], Error> {
-        self.export_symmetric_key_insecure(id, dest)
-    }
-
-    fn export_private_key_insecure<'data>(
-        &self,
-        id: KeyId,
-        dest: &'data mut [u8],
-    ) -> Result<&'data [u8], Error> {
-        self.export_private_key_insecure(id, dest)
-    }
-
     fn delete(&mut self, id: KeyId) -> Result<(), Error> {
         let key_info = self.get_key_info(id)?;
         if !key_info.permissions.delete {
             return Err(Error::NotAllowed);
         }
-        self.delete(id)
+        self.delete_insecure(id)
     }
-
-    fn is_key_available(&self, id: KeyId) -> bool {
+        fn is_key_available(&self, id: KeyId) -> bool {
         self.is_key_available(id)
     }
 

--- a/heimlig/src/integration/memory_key_store.rs
+++ b/heimlig/src/integration/memory_key_store.rs
@@ -362,10 +362,16 @@ pub(crate) mod test {
         assert_eq!(key_store.delete(UNKNOWN_KEY_ID), Err(Error::InvalidKeyId));
         assert!(key_store.delete(KEY1_INFO.id).is_ok());
         assert!(!KeyStore::is_key_available(&key_store, KEY1_INFO.id));
-        assert!(!InsecureKeyStore::is_key_available(&key_store, KEY1_INFO.id));
+        assert!(!InsecureKeyStore::is_key_available(
+            &key_store,
+            KEY1_INFO.id
+        ));
         assert!(key_store.delete(KEY2_INFO.id).is_ok());
         assert!(!KeyStore::is_key_available(&key_store, KEY2_INFO.id));
-        assert!(!InsecureKeyStore::is_key_available(&key_store, KEY2_INFO.id));
+        assert!(!InsecureKeyStore::is_key_available(
+            &key_store,
+            KEY2_INFO.id
+        ));
     }
 
     #[test]

--- a/heimlig/tests/aes_cbc.rs
+++ b/heimlig/tests/aes_cbc.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use heimlig::{
     client::api::SymmetricAlgorithm::AesCbc,
     common::jobs::{RequestType, Response},
-    hsm::{keystore::KeyStore, workers::aes_worker::AesWorker},
+    hsm::workers::aes_worker::AesWorker,
 };
 
 #[async_std::test]
@@ -22,7 +22,7 @@ async fn aes_cbc_encrypt_in_place() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::EncryptAesCbc,

--- a/heimlig/tests/aes_cmac.rs
+++ b/heimlig/tests/aes_cmac.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use heimlig::{
     common::jobs::{RequestType, Response},
     crypto,
-    hsm::{keystore::KeyStore, workers::aes_worker::AesWorker},
+    hsm::workers::aes_worker::AesWorker,
 };
 
 #[async_std::test]
@@ -19,7 +19,7 @@ async fn aes_cmac_calculate_verify() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::CalculateAesCmac,

--- a/heimlig/tests/aes_gcm.rs
+++ b/heimlig/tests/aes_gcm.rs
@@ -7,7 +7,7 @@ use heimlig::{
     client::api::SymmetricAlgorithm::AesGcm,
     common::jobs::{RequestType, Response},
     crypto,
-    hsm::{keystore::KeyStore, workers::aes_worker::AesWorker},
+    hsm::workers::aes_worker::AesWorker,
 };
 
 #[async_std::test]
@@ -24,7 +24,7 @@ async fn aes_gcm_encrypt_in_place() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::EncryptAesGcm,

--- a/heimlig/tests/chachapoly.rs
+++ b/heimlig/tests/chachapoly.rs
@@ -7,7 +7,7 @@ use heimlig::{
     client::api::SymmetricAlgorithm::ChaCha20Poly1305,
     common::jobs::{RequestType, Response},
     crypto,
-    hsm::{keystore::KeyStore, workers::chachapoly_worker::ChaChaPolyWorker},
+    hsm::workers::chachapoly_worker::ChaChaPolyWorker,
 };
 
 #[async_std::test]
@@ -24,7 +24,7 @@ async fn chachapoly_encrypt_in_place() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::EncryptChaChaPoly,

--- a/heimlig/tests/ecdsa.rs
+++ b/heimlig/tests/ecdsa.rs
@@ -5,7 +5,7 @@ pub use common::*;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use heimlig::{
     common::jobs::{RequestType, Response},
-    hsm::{keystore::KeyStore, workers::ecc_worker::EccWorker},
+    hsm::workers::ecc_worker::EccWorker,
 };
 use sha2::{Digest, Sha256};
 
@@ -21,7 +21,7 @@ async fn sign_verify_nist_p256() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::GenerateKeyPair,

--- a/heimlig/tests/hmac.rs
+++ b/heimlig/tests/hmac.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use heimlig::{
     common::jobs::{HashAlgorithm, RequestType, Response},
     crypto,
-    hsm::{keystore::KeyStore, workers::hmac_worker::HmacWorker},
+    hsm::workers::hmac_worker::HmacWorker,
 };
 
 #[async_std::test]
@@ -20,7 +20,7 @@ async fn calculate_verify_hmac_sha3_512() {
     let (mut client_requests, mut client_responses) = allocate_channel();
     let (mut worker_requests, mut worker_responses) = allocate_channel();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let (mut api, mut core, req_worker_rx, resp_worker_tx) = init_core(
         &[
             RequestType::CalculateHmac,

--- a/heimlig/tests/random.rs
+++ b/heimlig/tests/random.rs
@@ -8,7 +8,7 @@ use heimlig::{
         jobs::{Error, RequestType, Response},
         limits::MAX_RANDOM_SIZE,
     },
-    hsm::{keystore::KeyStore, workers::rng_worker::RngWorker},
+    hsm::workers::rng_worker::RngWorker,
 };
 
 #[async_std::test]
@@ -28,7 +28,7 @@ async fn get_random() {
     );
     let rng = init_rng();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let mut rng_worker = RngWorker {
         rng: &rng,
         key_store: &key_store,
@@ -69,7 +69,7 @@ async fn get_random_request_too_large() {
     );
     let rng = init_rng();
     let mut key_store = init_key_store(&KEY_INFOS);
-    let key_store: Mutex<NoopRawMutex, &mut (dyn KeyStore + Send)> = Mutex::new(&mut key_store);
+    let key_store: Mutex<NoopRawMutex, _> = Mutex::new(&mut key_store);
     let mut worker = RngWorker {
         rng: &rng,
         key_store: &key_store,


### PR DESCRIPTION
Splits the `KeyStore` trait into a base "insecure" version, which is intended to provide the raw access to the keystore without checks for permissions or types, and provides a blanket implementation of `KeyStore` for any type implementing `InsecureKeyStore`. This way, users can implement their own `KeyStore` if they want to fully control the checks, or they can provide an `InsecureKeyStore` and get for free the basic permission and key type checks. Heimlig and workers can still use `KeyStore` and access the insecure methods becasue `KeyStore` is a supertrait of `InsecureKeyStore`. 