### PR TITLE
Add explicit underlying type for "Raw" integration enums

### DIFF
--- a/heimlig/src/hsm/keystore.rs
+++ b/heimlig/src/hsm/keystore.rs
@@ -8,6 +8,8 @@ pub enum Error {
     NotAllowed,
     /// The requested key was not found.
     KeyNotFound,
+    /// The operation attempted to overwrite an existing key when it was not permitted
+    KeyAlreadyExists,
     /// The key store cannot handle the number of requested keys.
     KeyStoreTooSmall,
     /// Attempted to create a key store with duplicate storage IDs.

--- a/heimlig/src/integration/raw_errors.rs
+++ b/heimlig/src/integration/raw_errors.rs
@@ -3,7 +3,7 @@ use crate::crypto;
 use crate::hsm::keystore;
 
 /// Raw version of jobs::Error
-#[repr(C)]
+#[repr(C, u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum JobErrorRaw {
     /// No worker found for received request type.
@@ -25,7 +25,7 @@ pub enum JobErrorRaw {
 }
 
 /// Raw version of crypto::Error
-#[repr(C)]
+#[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum CryptoErrorRaw {
     /// Error during encryption.
@@ -59,7 +59,7 @@ pub enum CryptoErrorRaw {
 }
 
 /// Raw version of keystore::Error
-#[repr(C)]
+#[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum KeyStoreErrorRaw {
     /// The operation is not permitted

--- a/heimlig/src/integration/raw_errors.rs
+++ b/heimlig/src/integration/raw_errors.rs
@@ -66,6 +66,8 @@ pub enum KeyStoreErrorRaw {
     NotAllowed,
     /// The requested key was not found.
     KeyNotFound,
+    /// The operation attempted to overwrite an existing key when it was not permitted
+    KeyAlreadyExists,
     /// The key store cannot handle the amount of requested keys.
     KeyStoreTooSmall,
     /// Attempted to create a key store with duplicate storage IDs.
@@ -119,6 +121,7 @@ impl From<keystore::Error> for KeyStoreErrorRaw {
         match value {
             keystore::Error::NotAllowed => KeyStoreErrorRaw::NotAllowed,
             keystore::Error::KeyNotFound => KeyStoreErrorRaw::KeyNotFound,
+            keystore::Error::KeyAlreadyExists => KeyStoreErrorRaw::KeyAlreadyExists,
             keystore::Error::KeyStoreTooSmall => KeyStoreErrorRaw::KeyStoreTooSmall,
             keystore::Error::DuplicateIds => KeyStoreErrorRaw::DuplicateIds,
             keystore::Error::InvalidKeyId => KeyStoreErrorRaw::InvalidKeyId,

--- a/heimlig/src/integration/raw_jobs.rs
+++ b/heimlig/src/integration/raw_jobs.rs
@@ -41,7 +41,7 @@ pub struct RequestResponseRawPair {
 /// pointers have to point to valid addresses as they can be checked after casting. However, a
 /// nested enum member is not allowed as casting an enum from a value outside the enum range causes
 /// UB in Rust even without accessing the resulting enum.
-#[repr(C)]
+#[repr(C, u8)]
 #[derive(Clone, Copy, Debug, EnumCount)]
 pub enum RequestRaw {
     GetRandom {
@@ -400,7 +400,7 @@ pub enum RequestRaw {
 
 /// Raw response as it is written by clients to shared memory. This type is supposed to be synced
 /// with non-Rust (e.g. C++) clients via cbindgen.
-#[repr(C)]
+#[repr(C, u8)]
 #[derive(Clone, Copy, Debug, EnumCount)]
 pub enum ResponseRaw {
     Error {


### PR DESCRIPTION
Generated header by bindgen ended up implicitly using uint32_t as as underlying type on the C side, but Rust was using uint8_t in some cases. Now make everything explicit.

Also adds a new error for the KeyStore in case an existing key is not over writable but the user tries to overwrite it anyway.