### PR TITLE
Move common fields out of raw enums

### DIFF
--- a/heimlig/src/lib.rs
+++ b/heimlig/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(offset_of)]
 
 pub mod client;
 pub mod common;


### PR DESCRIPTION
ToDos for future PR:

- Make the same change to the Rust types.
- Remove the `#![feature(offset_of)]`.